### PR TITLE
Role mentions support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/node_modules
+/package-lock.json

--- a/src/classes/ChangelogChecker.js
+++ b/src/classes/ChangelogChecker.js
@@ -173,8 +173,8 @@ const createPost = (
                 },
             );
         
-            Utils.ping( post );
-            Utils.storeCheck( post, version, articleSection );
+            Utils.ping( client, post, articleSection );
+            Utils.storeCheck( client, post, version, articleSection );
             Utils.bdsCheck( post, version, articleSection );
         },
     ).catch(

--- a/src/files/config.json
+++ b/src/files/config.json
@@ -4,6 +4,10 @@
     "repeateInterval": 60000,
 
     "channel": "1019665690233405500",
+    "pingRoles": {
+        "Stable": "",
+        "Preview": ""
+    },
     "tags": {
         "Stable": "1019665978369507480",
         "Preview": "1019666001987653673"


### PR DESCRIPTION
This commit refactors the `Utils.ping` function to allow pinging users based on a role instead of the hardcoded `pings.json` file. Ping roles can be configured for preview and stable independantly within the config.json file.